### PR TITLE
添加郑州大学

### DIFF
--- a/list.tsv
+++ b/list.tsv
@@ -1,3 +1,4 @@
 学校	所在学院	URL
 中山大学南方学院	文学与传媒学院	http://wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/
-暨南大学	新闻与传播学院	https://xwxy.jnu.edu.cn/html/bks/zhuanyejianjie/2015/0923/293.html
+郑州大学	新闻与传播学院	http://www5.zzu.edu.cn/xinwen/info/1004/4710.htm
+


### PR DESCRIPTION
学校	所在学院	URL
中山大学南方学院	文学与传媒学院	http://wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/
郑州大学	新闻与传播学院	http://www5.zzu.edu.cn/xinwen/info/1004/4710.htm